### PR TITLE
🔧  (platform requirements) allows install on php 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		}
 	],
 	"require": {
-		"php": "^5.6|^7.0|^7.1"
+		"php": "^5.6|^7.0|^8.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7",


### PR DESCRIPTION
Addresses #4 

Needs more thorough testing but this allows composer install and doesn't throw any parse or deprecation errors.